### PR TITLE
Add Evebox to SELKS - v1

### DIFF
--- a/build-debian-live.sh
+++ b/build-debian-live.sh
@@ -239,6 +239,7 @@ mkdir -p config/includes.chroot/etc/iceweasel/profile/
 mkdir -p config/includes.chroot/etc/apt/sources.list.d/
 mkdir -p config/includes.chroot/etc/conky/
 mkdir -p config/includes.chroot/etc/alternatives/
+mkdir -p config/includes.chroot/etc/systemd/system/
 
 cd ../
 
@@ -287,6 +288,12 @@ cp staging/etc/apt/sources.list.d/elasticsearch.list Stamus-Live-Build/config/in
 # Copy stamus debian repo list file - 
 # holding latest Suricata,libhtp,Scirius and kernel packages
 cp staging/etc/apt/sources.list.d/selks.list Stamus-Live-Build/config/includes.chroot/etc/apt/sources.list.d/
+# Copy evebox repo file
+cp staging/etc/apt/sources.list.d/evebox.list Stamus-Live-Build/config/includes.chroot/etc/apt/sources.list.d/
+# Copy evebox systemd unit file
+cp staging/etc/systemd/system/evebox.service Stamus-Live-Build/config/includes.chroot/etc/systemd/system/
+# Copy evebox desktop shortcut.
+cp staging/usr/share/applications/Evebox.desktop Stamus-Live-Build/config/includes.chroot/etc/skel/Desktop/
 
 # Add core system packages to be installed
 echo "
@@ -319,7 +326,9 @@ if [[ -z "$GUI" ]]; then
   # this is for the lxde menu widgets - not the desktop shortcuts
   cp staging/usr/share/applications/Dashboards.desktop Stamus-Live-Build/config/includes.chroot/usr/share/applications/
   cp staging/usr/share/applications/Scirius.desktop Stamus-Live-Build/config/includes.chroot/usr/share/applications/
-  
+
+  # For Evebox to.
+  cp staging/usr/share/applications/Evebox.desktop Stamus-Live-Build/config/includes.chroot/usr/share/applications/
 fi
 
 # If -p (add packages) option is used - add those packages to the build

--- a/staging/config/hooks/chroot-inside-Debian-Live.chroot
+++ b/staging/config/hooks/chroot-inside-Debian-Live.chroot
@@ -64,6 +64,12 @@ mkdir -p /var/www/static
 apt-get install -y scirius
 ### END Scirius ###
 
+### START Evebox ###
+wget -O - -q "https://bintray.com/user/downloadSubjectPublicKey?username=jasonish" | apt-key add -
+apt-get update && apt-get install -y evebox
+systemctl enable evebox.service
+### END Evebox ###
+
 systemctl enable elasticsearch.service && \
 systemctl enable logstash.service && \
 systemctl enable suri_reloader.service

--- a/staging/config/hooks/chroot-inside-Debian-Live.chroot
+++ b/staging/config/hooks/chroot-inside-Debian-Live.chroot
@@ -20,8 +20,7 @@ echo " alias ll='ls $LS_OPTIONS -l'" >> /root/.bashrc
 ###  START Scirius ###
 # NOTE python-pip is already installed in the build script
 
-#pip install django==1.6.6 django-tables2 South GitPython pyinotify flup
-pip install django django-tables2 South GitPython pyinotify flup
+pip install django==1.8.7 django-tables2 South GitPython pyinotify flup
 
 ###  END Scirius ###
 

--- a/staging/etc/apt/sources.list.d/evebox.list
+++ b/staging/etc/apt/sources.list.d/evebox.list
@@ -1,0 +1,1 @@
+deb http://dl.bintray.com/jasonish/deb-evebox-latest jessie main

--- a/staging/etc/systemd/system/evebox.service
+++ b/staging/etc/systemd/system/evebox.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=EveBox Alert and Event Viewer
+Requires=network.target
+After=network.target
+
+[Service]
+ExecStart=/usr/bin/evebox -e http://localhost:9200 --host SELKS
+
+[Install]
+WantedBy=multi-user.target

--- a/staging/usr/share/applications/Evebox.desktop
+++ b/staging/usr/share/applications/Evebox.desktop
@@ -1,0 +1,12 @@
+#!/usr/bin/env xdg-open
+[Desktop Entry]
+Version=1.0
+Name=EveBox
+Icon=applications-internet
+Comment=Launch-EveBox-Web-Access
+Exec=iceweasel http://selks:5636
+Type=Application
+Categories=Application;System;
+StartupNotify=true
+Terminal=false
+


### PR DESCRIPTION
A preview of EveBox integrated into SELKS.

- Pulls latest Evebox build from my automatically built Debian packages of master (still not sure about this, or the versioning used - its a WIP).
- Adds Evebox launcher to the desktop.
- Uses systemd to start Evebox on start.

Currently Evebox binds to SELKS, as it has no auth. I haven't figured out how to put it behind the Django based reverse proxy for authentication yet. But wanted to put out what I had.