### PR TITLE
Update logstash.conf for breaking Logstash 5.0 changes

### DIFF
--- a/staging/etc/logstash/conf.d/logstash.conf
+++ b/staging/etc/logstash/conf.d/logstash.conf
@@ -17,7 +17,7 @@ filter {
     }
     
     ruby {
-      code => "if event['event_type'] == 'fileinfo'; event['fileinfo']['type']=event['fileinfo']['magic'].to_s.split(',')[0]; end;"
+      code => "if event.get('event_type') == 'fileinfo'; event.set('[fileinfo][type]', event.get('[fileinfo][magic]').to_s.split(',')[0]); end;"
     }
   
     metrics {


### PR DESCRIPTION
Logstash 5.0 throws an error when using direct event field references. This change fixes that. 

```
[2017-07-31T06:57:53,197][ERROR][logstash.filters.ruby    ] Ruby exception occurred: Direct event field references (i.e. event['field']) have been disabled in favor of using event get and set methods (e.g. event.get('field')). Please consult the Logstash 5.0 breaking changes documentation for more details.
```