### PR TITLE
Use polkit to acquire root for the setup scripts.

### DIFF
--- a/build-debian-live.sh
+++ b/build-debian-live.sh
@@ -308,8 +308,15 @@ cp staging/usr/share/applications/Setup-IDS-Interface.desktop Stamus-Live-Build/
 # Copy first time set up desktop shortcut.
 cp staging/usr/share/applications/FirstTime-Setup.desktop Stamus-Live-Build/config/includes.chroot/etc/skel/Desktop/
 
-# Copy first time set up desktop shortcut.
+# Same as above but for root
 cp staging/usr/share/applications/FirstTime-Setup.desktop Stamus-Live-Build/config/includes.chroot/root/Desktop/
+
+# Copy upgrade SELKS desktop shortcut.
+cp staging/usr/share/applications/Upgrade-SELKS.desktop Stamus-Live-Build/config/includes.chroot/etc/skel/Desktop/
+
+# Same as above but for root
+cp staging/usr/share/applications/Upgrade-SELKS.desktop Stamus-Live-Build/config/includes.chroot/root/Desktop/
+
 
 # Add core system packages to be installed
 echo "
@@ -330,7 +337,7 @@ python-pip debian-installer-launcher live-build apt-transport-https
 # Add system tools packages to be installed
 echo "
 ethtool bwm-ng iptraf htop rsync tcpreplay sysstat hping3 screen ngrep 
-tcpflow dsniff mc python-daemon wget curl vim bootlogd lsof libpolkit-agent libpolkit-backend libpolkit-gobject policykit-1" \
+tcpflow dsniff mc python-daemon wget curl vim bootlogd lsof libpolkit-agent-1-0 libpolkit-backend-1-0 libpolkit-gobject-1-0 policykit-1" \
 >> Stamus-Live-Build/config/package-lists/StamusNetworks-Tools.list.chroot
 
 # Unless otherwise specified the ISO will be with a Desktop Environment

--- a/build-debian-live.sh
+++ b/build-debian-live.sh
@@ -330,14 +330,14 @@ python-pip debian-installer-launcher live-build apt-transport-https
 # Add system tools packages to be installed
 echo "
 ethtool bwm-ng iptraf htop rsync tcpreplay sysstat hping3 screen ngrep 
-tcpflow dsniff mc python-daemon wget curl vim bootlogd lsof" \
+tcpflow dsniff mc python-daemon wget curl vim bootlogd lsof libpolkit-agent libpolkit-backend libpolkit-gobject policykit-1" \
 >> Stamus-Live-Build/config/package-lists/StamusNetworks-Tools.list.chroot
 
 # Unless otherwise specified the ISO will be with a Desktop Environment
 if [[ -z "$GUI" ]]; then 
   echo "lxde fonts-lyx wireshark terminator conky" \
   >> Stamus-Live-Build/config/package-lists/StamusNetworks-Gui.list.chroot
-  echo "wireshark terminator open-vm-tools open-vm-tools" \
+  echo "wireshark terminator open-vm-tools open-vm-tools lxpolkit" \
   >> Stamus-Live-Build/config/package-lists/StamusNetworks-Gui.list.chroot
   
   #echo "task-xfce-desktop" >> Stamus-Live-Build/config/package-lists/desktop.list.chroot

--- a/staging/usr/share/applications/FirstTime-Setup.desktop
+++ b/staging/usr/share/applications/FirstTime-Setup.desktop
@@ -5,10 +5,9 @@ Name=FirstTime-Setup.desktop
 #Icon=preferences-other
 Icon=system
 Comment=SetupIDSInterface
-Exec=/opt/selks/Scripts/Setup/selks-first-time-setup_stamus.sh
+Exec=/usr/bin/pkexec "/opt/selks/Scripts/Setup/selks-first-time-setup_stamus.sh" "$@"
 Type=Application
 Categories=Application;System;
 StartupNotify=true
 Terminal=true
-
-
+X-KeepTerminal=true

--- a/staging/usr/share/applications/Upgrade-SELKS.desktop
+++ b/staging/usr/share/applications/Upgrade-SELKS.desktop
@@ -1,11 +1,12 @@
 #!/usr/bin/env xdg-open
+
 [Desktop Entry]
 Version=1.0
-Name=Setup-IDS-Interface
+Name=Upgrade-SELKS
 #Icon=preferences-other
 Icon=system
-Comment=SetupIDSInterface
-Exec=/usr/bin/pkexec "/opt/selks/Scripts/Setup/selks-setup-ids-interface.sh" "$@"
+Comment=Upgrade SELKS
+Exec=/usr/bin/pkexec "/opt/selks/Scripts/Setup/selks-upgrade_stamus.sh" "$@"
 Type=Application
 Categories=Application;System;
 StartupNotify=true

--- a/staging/usr/share/polkit-1/actions/org.stamusnetworks.firsttimesetup.policy
+++ b/staging/usr/share/polkit-1/actions/org.stamusnetworks.firsttimesetup.policy
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE policyconfig PUBLIC
+ "-//freedesktop//DTD PolicyKit Policy Configuration 1.0//EN"
+ "http://www.freedesktop.org/standards/PolicyKit/1/policyconfig.dtd">
+
+<policyconfig>
+
+  <action id="org.freedesktop.policykit.pkexec.run-selksfirsttimesetup">
+    <description>Run the first time setup script as root</description>
+    <message>Authentication is required to run SELKS First Time Setup</message>
+    <defaults>
+      <allow_any>auth_admin</allow_any>
+      <allow_inactive>auth_admin</allow_inactive>
+      <allow_active>auth_admin</allow_active>
+    </defaults>
+    <annotate key="org.freedesktop.policykit.exec.path">/opt/selks/Scripts/Setup/selks-first-time-setup_stamus.sh</annotate>
+    <annotate key="org.freedesktop.policykit.exec.allow_gui">TRUE</annotate>
+  </action>
+
+</policyconfig>

--- a/staging/usr/share/polkit-1/actions/org.stamusnetworks.setupidsinterface.policy
+++ b/staging/usr/share/polkit-1/actions/org.stamusnetworks.setupidsinterface.policy
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE policyconfig PUBLIC
+ "-//freedesktop//DTD PolicyKit Policy Configuration 1.0//EN"
+ "http://www.freedesktop.org/standards/PolicyKit/1/policyconfig.dtd">
+
+<policyconfig>
+
+  <action id="org.freedesktop.policykit.pkexec.run-selkssetupidsinterface">
+    <description>Run Setup IDS interface as root</description>
+    <message>Authentication is required to run Setup IDS interface</message>
+    <defaults>
+      <allow_any>auth_admin</allow_any>
+      <allow_inactive>auth_admin</allow_inactive>
+      <allow_active>auth_admin</allow_active>
+    </defaults>
+    <annotate key="org.freedesktop.policykit.exec.path">/opt/selks/Scripts/Setup/selks-setup-ids-interface.sh</annotate>
+    <annotate key="org.freedesktop.policykit.exec.allow_gui">TRUE</annotate>
+  </action>
+
+</policyconfig>

--- a/staging/usr/share/polkit-1/actions/org.stamusnetworks.update.policy
+++ b/staging/usr/share/polkit-1/actions/org.stamusnetworks.update.policy
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE policyconfig PUBLIC
+ "-//freedesktop//DTD PolicyKit Policy Configuration 1.0//EN"
+ "http://www.freedesktop.org/standards/PolicyKit/1/policyconfig.dtd">
+
+<policyconfig>
+
+  <action id="org.freedesktop.policykit.pkexec.run-selksupgrade">
+    <description>Run SELKS upgrade as root</description>
+    <message>Authentication is required to run SELKS upgrade</message>
+    <defaults>
+      <allow_any>auth_admin</allow_any>
+      <allow_inactive>auth_admin</allow_inactive>
+      <allow_active>auth_admin</allow_active>
+    </defaults>
+    <annotate key="org.freedesktop.policykit.exec.path">/opt/selks/Scripts/Setup/selks-upgrade_stamus.sh</annotate>
+    <annotate key="org.freedesktop.policykit.exec.allow_gui">TRUE</annotate>
+  </action>
+
+</policyconfig>

--- a/staging/usr/share/polkit-1/rules.d/org.stamusnetworks.rules
+++ b/staging/usr/share/polkit-1/rules.d/org.stamusnetworks.rules
@@ -1,0 +1,6 @@
+# Allow all users in the sudo group to run the SELKS setup scripts
+polkit.addRule(function(action, subject) {
+	    if ((action.id == "org.freedesktop.policykit.pkexec.run-selksfirsttimesetup" || action.id == "org.freedesktop.policykit.pkexec.run-selkssetupidsinterface" || action.id == "org.freedesktop.policykit.pkexec.run-selksupgrade") && subject.isInGroup("sudo")) {
+            return polkit.Result.YES;
+    }
+});


### PR DESCRIPTION
This patch updates the installation script to use polkit for acquiring root access for running the setup scripts from the desktop. This patch is needed for commit 233716fb5c584a88c07bc3eb071f3f6a76942a8d in selks-script. Now that we no longer use sudo in the script but verify for root at the beginning of the scripts, we have to execute the scripts from the desktop files as root. This is done using polkit.

The installation script was altered to include the necessary packages. The desktop files were updated to use pkexec (polkit). A new desktop file for upgrading SELKS was written and included for making it easier to update SELKS from a desktop environment.

The rules are setup in a way that for the specific setup files, if they are executed by a user in the 'sudo' group access is granted.

This patch will make the terminal disappear directly after execution is done. To prevent this an additional entry in the setup scripts is required. Something like this at the end of every script:
```
echo -e "Press any key to close the terminal..."
read line
```