### PR TITLE
Update Moloch to the latest version 1.6.1.

### DIFF
--- a/scripts/SELKS4-SELKS5/SN-S4-S5-Upgrade.sh
+++ b/scripts/SELKS4-SELKS5/SN-S4-S5-Upgrade.sh
@@ -610,8 +610,8 @@ curl -X POST "localhost:9200/_aliases" -H 'Content-Type: application/json' -d'
 mkdir -p /opt/molochtmp
 cd /opt/molochtmp/ && \
 apt-get update && apt-get install -y libjson-perl libyaml-dev libcrypto++6
-wget https://files.molo.ch/builds/ubuntu-18.04/moloch_1.5.3-1_amd64.deb
-dpkg -i moloch_1.5.3-1_amd64.deb
+wget https://files.molo.ch/builds/ubuntu-18.04/moloch_1.6.1-1_amd64.deb
+dpkg -i moloch_1.6.1-1_amd64.deb
 
 
 cd /opt/

--- a/staging/config/hooks/live/chroot-inside-Debian-Live.hook.chroot
+++ b/staging/config/hooks/live/chroot-inside-Debian-Live.hook.chroot
@@ -200,8 +200,8 @@ chmod g+w /var/run/suricata/ -R
 mkdir -p /opt/molochtmp
 cd /opt/molochtmp/ && \
 apt-get update && apt-get install -y libjson-perl libyaml-dev libcrypto++6 libwww-perl
-wget https://files.molo.ch/builds/ubuntu-18.04/moloch_1.5.3-1_amd64.deb
-dpkg -i moloch_1.5.3-1_amd64.deb
+wget https://files.molo.ch/builds/ubuntu-18.04/moloch_1.6.1-1_amd64.deb
+dpkg -i moloch_1.6.1-1_amd64.deb
 
 cd /opt/
 rm /opt/molochtmp -r


### PR DESCRIPTION
Like the title says.
New versions of Moloch have been published since releasing the BETA ISO. There are no new breaking changes or new dependencies.
Staying up-to-date will require some new update policy, simply holding the package isn't a permanent solution. I would suggest some sort of update policy in selks-upgrade_stamus.sh.

Cheers,
Jeroen Rijken