### PR TITLE
Fix elasticsearch-curator version in apt sources list. Add it to the upgrade script.

### DIFF
--- a/scripts/SELKS4-SELKS5/SN-S4-S5-Upgrade.sh
+++ b/scripts/SELKS4-SELKS5/SN-S4-S5-Upgrade.sh
@@ -52,7 +52,7 @@ if [ -f /etc/apt/sources.list.d/curator5.list ];
 then
     
     # if the filename exists - make sure we don't overwrite.
-    mv /etc/apt/sources.list.d/curator5.list /opt/selks/preupgrade/curator5list.orig
+    mv /etc/apt/sources.list.d/curator5.list /opt/selks/preupgrade/curator5.list.orig
     
 fi
 

--- a/scripts/SELKS4-SELKS5/SN-S4-S5-Upgrade.sh
+++ b/scripts/SELKS4-SELKS5/SN-S4-S5-Upgrade.sh
@@ -48,6 +48,18 @@ cat >> /etc/apt/sources.list.d/elastic-6.x.list <<EOF
 deb https://artifacts.elastic.co/packages/6.x/apt stable main
 EOF
 
+if [ -f /etc/apt/sources.list.d/curator5.list ];
+then
+    
+    # if the filename exists - make sure we don't overwrite.
+    mv /etc/apt/sources.list.d/curator5.list /opt/selks/preupgrade/curator5list.orig
+    
+fi
+
+cat >> /etc/apt/sources.list.d/curator5.list <<EOF
+dev [arch=amd64] https://packages.elastic.co/curator/5/debian9 stable main
+EOF
+
 if [ -f /etc/nginx/sites-available/default ];
 then
     
@@ -607,9 +619,13 @@ curl -X POST "localhost:9200/_aliases" -H 'Content-Type: application/json' -d'
 }
 '
 
+# Install elasticsearch-curator
+apt-get update && install -y elasticsearch-curator
+
+# Install Moloch
 mkdir -p /opt/molochtmp
 cd /opt/molochtmp/ && \
-apt-get update && apt-get install -y libjson-perl libyaml-dev libcrypto++6
+apt-get install -y libjson-perl libyaml-dev libcrypto++6
 wget https://files.molo.ch/builds/ubuntu-18.04/moloch_1.6.1-1_amd64.deb
 dpkg -i moloch_1.6.1-1_amd64.deb
 

--- a/staging/config/hooks/live/chroot-inside-Debian-Live.hook.chroot
+++ b/staging/config/hooks/live/chroot-inside-Debian-Live.hook.chroot
@@ -26,7 +26,7 @@ deb https://artifacts.elastic.co/packages/6.x/apt stable main
 EOF
 
 cat >> /etc/apt/sources.list.d/curator5.list <<EOF
-deb [arch=amd64] https://packages.elastic.co/curator/5/debian stable main
+deb [arch=amd64] https://packages.elastic.co/curator/5/debian9 stable main
 EOF
 
 cat >> /etc/apt/sources.list.d/evebox.list <<EOF


### PR DESCRIPTION
The upgrade script didn't have the elasticsearch-curator package repo setup at all so I added it. This fixes #142.