### PR TITLE
Remove logstash PID

### DIFF
--- a/staging/etc/logrotate.d/suricata
+++ b/staging/etc/logrotate.d/suricata
@@ -8,7 +8,6 @@
 	dateext
 	postrotate
 	    /bin/kill -HUP $(cat /var/run/suricata.pid)
-	    /bin/kill -HUP $(cat /var/run/logstash.pid)
 	endscript
 }
 


### PR DESCRIPTION
The logstash systemd service file doesn't specify a PID file, preventing logrotate form working properly. To test this, run the following command:
`logrotate --force /etc/logrotate.d/suricata`

I'm not sure why logstash would even be a requirement for this logrotate file, since the data is indexed in Elasticsearch anyway. Remove the logstash PID dependency.