### PR TITLE
Remove Moloch configuration from NGINX

### DIFF
--- a/staging/config/hooks/live/chroot-inside-Debian-Live.hook.chroot
+++ b/staging/config/hooks/live/chroot-inside-Debian-Live.hook.chroot
@@ -144,11 +144,6 @@ server {
         expires 30d;
     }
 
-    location /app/moloch/ {
-        proxy_pass https://127.0.0.1:8005;
-        proxy_redirect off;
-    }
-
     location / {
         proxy_pass http://127.0.0.1:8000;
         proxy_read_timeout 600;


### PR DESCRIPTION
Moloch redirection is handled by the root location. This is necessary for StamusNetworks/KTS6#5.