### PR TITLE
Change GeoIP field name for dest_ip to not overlap with GeoIP for src_ip

### DIFF
--- a/staging/etc/logstash/conf.d/logstash.conf
+++ b/staging/etc/logstash/conf.d/logstash.conf
@@ -59,7 +59,7 @@ filter {
     if [dest_ip]  {
     geoip {
       source => "dest_ip" 
-      target => "geoip" 
+      target => "geoip_dest" 
       #database => "/opt/logstash/vendor/geoip/GeoLiteCity.dat" 
       #add_field => [ "[geoip][coordinates]", "%{[geoip][longitude]}" ]
       #add_field => [ "[geoip][coordinates]", "%{[geoip][latitude]}"  ]

--- a/staging/etc/logstash/elasticsearch6-template.json
+++ b/staging/etc/logstash/elasticsearch6-template.json
@@ -39,6 +39,15 @@
             "latitude" : { "type" : "half_float" },
             "longitude" : { "type" : "half_float" }
           }
+        },
+        "geoip_dest"  : {
+          "dynamic": true,
+          "properties" : {
+            "ip": { "type": "ip" },
+            "location" : { "type" : "geo_point" },
+            "latitude" : { "type" : "half_float" },
+            "longitude" : { "type" : "half_float" }
+          }
         }
       }
     }


### PR DESCRIPTION
This commit renames the `geoip` field for `dest_ip` to `geoip_dest` in
`logstash.conf` and creates a new mapping in `elasticsearch6-template.json`.

In logstash configuration, GeoIP is used for both `dest_ip` and `src_ip`
if both are present. However, the `target` field have the same name
(`geoip`) for both, so in the end the `dest_ip` GeoIP will overwrite the
`src_ip` one.

Fixes #183 