### PR TITLE
Improve the ./easy-setup.sh script

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -15,6 +15,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+
 version: '3.4'
 
 networks:
@@ -43,7 +44,7 @@ services:
     environment:
       - discovery.type=single-node
       - xpack.security.enabled=false
-      - "ES_JAVA_OPTS=-Xms2g -Xmx2g"
+      - ES_JAVA_OPTS=-Xms${ELASTIC_MEMORY:-2G} -Xmx${ELASTIC_MEMORY:-2G}
     volumes:
       - ${ELASTIC_DATAPATH:-elastic-data}:/usr/share/elasticsearch/data
     ulimits:
@@ -158,3 +159,6 @@ services:
       - 443:443
     networks:
       network:
+      
+      
+


### PR DESCRIPTION
- **not use docker group anymore (bad practice) -> run script as root instead**

The use of "docker" group is considered bad practice because, as docker engine runs as root, it gives root privileges to any user in the group. Unlike sudo, there is no password check on the docker command so this could lead to security issues.

The use of the docker group also made the script less conveniant since the user had to log off and in again for the new group to be taken into account.

- **Command line options for installing docker, compose and portainer in non interactive mode**

Following PR #343 , it can be usefull to be able to install components (docker, compose or portainer) during a non interactive run of the script. Therefore, I'm introducing `--install-docker`,  `--install-docker-compose`,  `--install-portainer` and `--install-all`
 options.
 When used in interactive mode, the user will not be prompted for those either.
 
 
- **update disclaimer with tested linux**

Updating the initial disclaimer with the distros and versions the script has been tested on