### PR TITLE
docker: Give logstash 512M by default

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -81,7 +81,7 @@ services:
       timeout: 5s
       retries: 3
       start_period: 30s
-    mem_limit: ${LOGSTASH_MEMORY:-2G}
+    mem_limit: ${LOGSTASH_MEMORY:-512M}
     volumes:
       - suricata-logs:/var/log/suricata:ro
       - ./containers-data/logstash/conf.d/logstash.conf:/usr/share/logstash/pipeline/logstash.conf

--- a/docker/easy-setup.sh
+++ b/docker/easy-setup.sh
@@ -66,7 +66,7 @@ function Help(){
     echo -e " --es-memory"
     echo -e "       Amount of memory to give to the elasticsearch java heap. Accepted units are 'm','M','g','G'. ex \"--es-memory 512m\" or \"--es-memory 4G\". Default is '2G'\n"
     echo -e " --ls-memory"
-    echo -e "       Amount of memory to give to the logstash java heap. Accepted units are 'm','M','g','G'. ex \"--es-memory 512m\" or \"--es-memory 4G\". Default is '2G'\n"
+    echo -e "       Amount of memory to give to the logstash java heap. Accepted units are 'm','M','g','G'. ex \"--ls-memory 512m\" or \"--ls-memory 4G\". Default is '512M'\n"
     echo -e " --restart-mode"
     echo -e "       'no': never restart automatically the containers, 'always': automatically restart the containers even if they have been manually stopped, 'on-failure': only restart the containers if they failed,'unless-stopped': always restart the container except if it has been manually stopped"
     echo -e " --print-options"


### PR DESCRIPTION
Give logstash 512M by default and correct the print that sayed "es-memory" instead of "logstash-memory"