### PR TITLE
docker: added cron container 

### DIFF
--- a/docker/containers-data/cron-jobs/README.md
+++ b/docker/containers-data/cron-jobs/README.md
@@ -1,0 +1,15 @@
+
+Cron jobs are run in an alpine container. It uses the busybox "crond".
+Scripts to be run have to be placed into the appropriate folder.
+
+
+This is the crontab root file inside the container :
+ ```bash
+# min	hour    day	month	weekday	command
+*/15	*	    *	*	    *	    run-parts /etc/periodic/15min
+0	    *	    *	*	    *	    run-parts /etc/periodic/hourly
+0	    2	    *	*	    *	    run-parts /etc/periodic/daily
+0	    3	    *	*	    6	    run-parts /etc/periodic/weekly
+0	    5	    1	*	    *	    run-parts /etc/periodic/monthly
+ ```
+ where `/etc/periodic/` is mapped on host filesystem at `SELKS/docker/containers-data/cron-jobs/`

--- a/docker/containers-data/cron-jobs/daily/scirius-update-suri-rules.sh
+++ b/docker/containers-data/cron-jobs/daily/scirius-update-suri-rules.sh
@@ -1,0 +1,4 @@
+#! /bin/sh
+
+echo "Updating Suricata rules from Scirius"
+docker exec scirius python /opt/scirius/manage.py updatesuricata && echo "done." || echo "ERROR"

--- a/docker/containers-data/cron-jobs/daily/suricata-logrotate.sh
+++ b/docker/containers-data/cron-jobs/daily/suricata-logrotate.sh
@@ -1,0 +1,9 @@
+#! /bin/sh
+#
+# Example of rotating the logs within the Suricata container.
+#
+# Add -v for verbose output.
+# Add -f to force rotation.
+
+echo "Rotating Suricata logs"
+docker exec suricata logrotate -v /etc/logrotate.d/suricata $@ && echo "done." || echo "ERROR"

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -27,7 +27,14 @@ volumes:
   scirius-data: #for scirius data persistency
   scirius-static: #statics files to be served by nginx
   suricata-run: #path where the suricata socket resides
+  suricata-logs:
+  suricata-logrotate:
+    driver_opts:
+      type: none
+      o: bind
+      device: ./containers-data/suricata/logrotate
   logstash-sincedb: #where logstash stores it's state so it doesn't re-ingest
+
 
 services:
   
@@ -110,6 +117,7 @@ services:
        - suricata-rules:/etc/suricata/rules
        - suricata-run:/var/run/suricata/
        - ./containers-data/suricata/etc:/etc/suricata
+       - suricata-logrotate:/etc/logrotate.d/
     
   scirius:
     container_name: scirius

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -163,3 +163,21 @@ services:
       - 443:443
     networks:
       network:
+
+  cron:
+    # This containers handles crontabs for the other containers, following the 1 task per container principle.
+    # It is based on  `docker:latest` image, wich is an alpine image with docker binary
+    container_name: cron
+    image: docker:latest
+    command: ["crond", "-f", "-l", "8"]
+    restart: ${RESTART_MODE:-unless-stopped}
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock # This bind-mout allows using the hosts docker deamon instead of created one inside the container
+
+      # Those volumes will contain the cron jobs
+      - ./containers-data/cron-jobs/15min:/etc/periodic/15min/:ro
+      - ./containers-data/cron-jobs/daily:/etc/periodic/daily/:ro
+      - ./containers-data/cron-jobs/hourly:/etc/periodic/hourly/:ro
+      - ./containers-data/cron-jobs/monthly:/etc/periodic/monthly/:ro
+      - ./containers-data/cron-jobs/weekly:/etc/periodic/weekly/:ro
+

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -177,12 +177,13 @@ services:
     # It is based on  `docker:latest` image, wich is an alpine image with docker binary
     container_name: cron
     image: docker:latest
-    command: ["crond", "-f", "-l", "8"]
+    command: [sh, -c, "echo '*	*	 *	*	 *	run-parts /etc/periodic/1min' >> /etc/crontabs/root && crond -f -l 8"]
     restart: ${RESTART_MODE:-unless-stopped}
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock # This bind-mout allows using the hosts docker deamon instead of created one inside the container
 
       # Those volumes will contain the cron jobs
+      - ./containers-data/cron-jobs/1min:/etc/periodic/1min/:ro
       - ./containers-data/cron-jobs/15min:/etc/periodic/15min/:ro
       - ./containers-data/cron-jobs/daily:/etc/periodic/daily/:ro
       - ./containers-data/cron-jobs/hourly:/etc/periodic/hourly/:ro

--- a/docker/easy-setup.sh
+++ b/docker/easy-setup.sh
@@ -927,6 +927,12 @@ if ! grep -q sse4_2 /proc/cpuinfo; then
   echo "ML_ENABLED=false" >> ${BASEDIR}/.env
 fi
 
+####################
+# CREATING FOLDERS #
+####################
+mkdir -p ${BASEDIR}/containers-data/cron-jobs/{15min,hourly,daily,weekly,monthly}
+mkdir -p ${BASEDIR}/containers-data/suricata/{logs,logrotate}
+
 
 ######################
 # PULLING           #

--- a/docker/easy-setup.sh
+++ b/docker/easy-setup.sh
@@ -930,7 +930,7 @@ fi
 ####################
 # CREATING FOLDERS #
 ####################
-mkdir -p ${BASEDIR}/containers-data/cron-jobs/{15min,hourly,daily,weekly,monthly}
+mkdir -p ${BASEDIR}/containers-data/cron-jobs/{1min,15min,hourly,daily,weekly,monthly}
 mkdir -p ${BASEDIR}/containers-data/suricata/{logs,logrotate}
 
 

--- a/docker/scripts/readpcap.sh
+++ b/docker/scripts/readpcap.sh
@@ -255,4 +255,4 @@ docker run --name suricata-replay --rm -it \
 -v ${BASEDIR}/containers-data/suricata/etc:/etc/suricata \
 -v ${HOST_PATH}:${LOCAL_PATH} \
 --entrypoint /etc/suricata/new_entrypoint.sh \
-jasonish/suricata:master -k none -r ${LOCAL_PATH} --runmode ${MODE} -l /var/log/suricata --set sensor-name=${FILENAME}
+jasonish/suricata:master-amd64 -k none -r ${LOCAL_PATH} --runmode ${MODE} -l /var/log/suricata --set sensor-name=${FILENAME}


### PR DESCRIPTION
Added a new container "cron" using official `docker` image.
-Has access to the docker socket
-Runs cron as a foreground process.
-Scripts are passed through a bind-mout

Added daily scripts for executing logrotate in Suricata container and pushing rules to suri in Scirius container ([see here](https://github.com/StamusNetworks/SELKS/pull/384/files?file-filters%5B%5D=.sh&show-viewed-files=true))