### PR TITLE
improve headless provisioning of SELKS on docker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 *~
 Stamus-Live-Build
+
+.vagrant/

--- a/docker/Vagrantfile
+++ b/docker/Vagrantfile
@@ -14,8 +14,8 @@ $provision = <<-SCRIPT
 SCRIPT
 
 NAME = 'selks'.freeze
-CPU = 4
-MEM = 8196
+CPU = 6
+MEM = 12288
 
 Vagrant.configure(2) do |config|
   config.vm.define NAME do |box|

--- a/docker/Vagrantfile
+++ b/docker/Vagrantfile
@@ -1,0 +1,34 @@
+$provision = <<-SCRIPT
+  export DEBIAN_FRONTEND=noninteractive
+
+  apt-get udpate
+  apt-get install -y curl
+
+  ip link add tppdummy0 type dummy && ip link set tppdummy0 up && ip link set dev tppdummy0 mtu 9000
+
+  cd /selks
+  time ./easy-setup.sh  --non-interactive -i tppdummy0 --iA --es-memory 2G --ls-memory 1G
+  time docker-compose up -d
+SCRIPT
+
+NAME = 'selks'.freeze
+CPU = 4
+MEM = 8196
+
+Vagrant.configure(2) do |config|
+  config.vm.define NAME do |box|
+    box.vm.box = 'debian/bullseye64'
+    box.vm.hostname = NAME
+    box.vm.network :private_network, ip: '192.168.56.10'
+    box.vm.synced_folder '.', '/selks', type: 'rsync', rsync__exclude: '.git/'
+    box.vm.provider :virtualbox do |vb|
+      vb.customize ['modifyvm', :id, '--memory', MEM]
+      vb.customize ['modifyvm', :id, '--cpus', CPU]
+    end
+    box.vm.provider 'libvirt' do |v, _|
+      v.cpus = CPU
+      v.memory = MEM
+    end
+    box.vm.provision 'shell', inline: $provision
+  end
+end

--- a/docker/Vagrantfile
+++ b/docker/Vagrantfile
@@ -2,12 +2,14 @@ $provision = <<-SCRIPT
   export DEBIAN_FRONTEND=noninteractive
 
   apt-get udpate
-  apt-get install -y curl
+  apt-get install -y curl python3 python3-pip python3-venv
 
   ip link add tppdummy0 type dummy && ip link set tppdummy0 up && ip link set dev tppdummy0 mtu 9000
 
   cd /selks
-  time ./easy-setup.sh  --non-interactive -i tppdummy0 --iA --es-memory 2G --ls-memory 1G
+  python3 -m venv .venv
+  source .venv/bin/activate && pip install docker-compose
+  time ./easy-setup.sh  --non-interactive -i tppdummy0 --iA --es-memory 4G --ls-memory 2G
   time docker-compose up -d
 SCRIPT
 

--- a/docker/easy-setup.sh
+++ b/docker/easy-setup.sh
@@ -124,6 +124,10 @@ _arg_es_memory=
 _arg_ls_memory=
 _arg_restart_mode=
 _arg_print_options="off"
+_arg_docker_run=
+
+# -ti flag indicates a interactive terminal session which might break in automated provisioning scripts
+[ -z "$PS1" ] || _arg_docker_run="-ti"
 
 
 # Function that prints general usage of the script.
@@ -702,7 +706,7 @@ SSLDIR="${BASEDIR}/containers-data/nginx/ssl"
 function check_scirius_key_cert(){
   # usage : check_scirius_key_cert [path_to_files] [filename_without_extension]
   # example : check_scirius_key_cert [path_to_files] [filename_without_extension]
-  output=$(docker run --rm -it -v ${1}:/etc/nginx/ssl nginx /bin/bash -c "openssl x509 -in /etc/nginx/ssl/scirius.crt -pubkey -noout -outform pem | sha256sum; openssl pkey -in /etc/nginx/ssl/scirius.key -pubout -outform pem | sha256sum" || echo -e "${red}-${reset} Error while checking certificate against key")
+  output=$(docker run --rm ${_arg_docker_run} -v ${1}:/etc/nginx/ssl nginx /bin/bash -c "openssl x509 -in /etc/nginx/ssl/scirius.crt -pubkey -noout -outform pem | sha256sum; openssl pkey -in /etc/nginx/ssl/scirius.key -pubout -outform pem | sha256sum" || echo -e "${red}-${reset} Error while checking certificate against key")
   
   SAVEIFS=$IFS   # Save current IFS
   IFS=$'\n'      # Change IFS to new line
@@ -721,7 +725,7 @@ function check_scirius_key_cert(){
   fi
 }
 function generate_scirius_certificate(){
-  docker run --rm -it -v ${1}:/etc/nginx/ssl nginx openssl req -new -nodes -x509 -subj "/C=FR/ST=IDF/L=Paris/O=Stamus/CN=SELKS" -days 3650 -keyout /etc/nginx/ssl/scirius.key -out /etc/nginx/ssl/scirius.crt -extensions v3_ca && echo -e "${green}+${reset} Certificate generated successfully" || echo -e "${red}-${reset} Error while generating certificate with openssl"
+  docker run --rm ${_arg_docker_run} -v ${1}:/etc/nginx/ssl nginx openssl req -new -nodes -x509 -subj "/C=FR/ST=IDF/L=Paris/O=Stamus/CN=SELKS" -days 3650 -keyout /etc/nginx/ssl/scirius.key -out /etc/nginx/ssl/scirius.crt -extensions v3_ca && echo -e "${green}+${reset} Certificate generated successfully" || echo -e "${red}-${reset} Error while generating certificate with openssl"
   check_scirius_key_cert ${1}
   return $?
 }
@@ -926,7 +930,7 @@ fi
 # Generate KEY FOR DJANGO #
 ###########################
 
-output=$(docker run --rm -it python:3.9.5-slim-buster /bin/bash -c "python -c \"import secrets; print(secrets.token_urlsafe())\"")
+output=$(docker run --rm ${_arg_docker_run} python:3.9.5-slim-buster /bin/bash -c "python -c \"import secrets; print(secrets.token_urlsafe())\"")
 
 echo "SCIRIUS_SECRET_KEY=${output}" >> ${BASEDIR}/.env
 


### PR DESCRIPTION
* detect missing terminal (such as vagrant provision script), drop `-ti` docker flag that breaks in such env
* Vagrantfile to test the change and easily create a SELKS VM