### PR TITLE
docker: support dummy interface, macOS

### DIFF
--- a/docker/.gitignore
+++ b/docker/.gitignore
@@ -1,0 +1,10 @@
+# Do not ignore entrypoint
+!containers-data/suricata/etc/new_entrypoint.sh
+# Ignore logs and other dynamic data
+containers-data/suricata/etc/*
+containers-data/suricata/logs/*
+containers-data/scirius/logs/*
+containers-data/nginx/ssl/*
+
+# Ignore the environment secrets
+.env

--- a/docker/containers-data/suricata/etc/new_entrypoint.sh
+++ b/docker/containers-data/suricata/etc/new_entrypoint.sh
@@ -28,4 +28,9 @@ done
 mkdir -p /var/log/suricata/fpc/
 cat /etc/suricata/suricata.yaml | grep "include: selks6-addin.yaml" || echo "include: selks6-addin.yaml" >> /etc/suricata/suricata.yaml && echo 'suricata.yaml edited'
 
+if [[ "${CREATE_DUMMY_INTERFACE}" ]]; then
+    echo "Creating dummy interface"
+    ip link add dummy0 type dummy && ip link set dummy0 up
+fi
+
 exec /docker-entrypoint.sh $@

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -103,7 +103,7 @@ services:
           
   suricata:
     container_name: suricata
-    image: jasonish/suricata:master-amd64
+    image: jasonish/suricata:master
     entrypoint: /etc/suricata/new_entrypoint.sh
     restart: ${RESTART_MODE:-unless-stopped}
     depends_on:
@@ -111,6 +111,7 @@ services:
         condition: service_healthy
     environment:
       - SURICATA_OPTIONS=${INTERFACES} -vvv --set sensor-name=suricata
+      - CREATE_DUMMY_INTERFACE=${CREATE_DUMMY_INTERFACE:-false}
     cap_add:
       - NET_ADMIN
       - SYS_NICE

--- a/docker/scripts/readpcap.sh
+++ b/docker/scripts/readpcap.sh
@@ -289,7 +289,7 @@ if [[ "${test}" == *"Error"* ]]; then
   exit 1
 fi
 
-IMAGE="jasonish/suricata:master-amd64"
+IMAGE="jasonish/suricata:master"
 OPTIONSTRING=""
 
 if [[ -n "${_arg_set_rulefile}" ]]; then
@@ -302,7 +302,7 @@ if [[ -n "${_arg_set_rulefile}" ]]; then
   fi
   OPTIONSTRING="${OPTIONSTRING} -s /rules/${RULE_FILENAME}"
   RULE_MOUNT="-v ${RULE_HOST_PATH}:/rules/${RULE_FILENAME}"
-  IMAGE="jasonish/suricata:master-amd64-profiling"
+  IMAGE="jasonish/suricata:master-profiling"
 
 elif [[ -n "${_arg_set_rulefile_exclusive}" ]]; then
   echo ${_arg_set_rulefile_exclusive}
@@ -314,7 +314,7 @@ elif [[ -n "${_arg_set_rulefile_exclusive}" ]]; then
   fi
   OPTIONSTRING="${OPTIONSTRING} -S /rules/${RULE_FILENAME}"
   RULE_MOUNT="-v ${RULE_HOST_PATH}:/rules/${RULE_FILENAME}"
-  IMAGE="jasonish/suricata:master-amd64-profiling"
+  IMAGE="jasonish/suricata:master-profiling"
 fi
 
 if [[ -n "${_arg_set_rulefile}" && -n "${_arg_set_rulefile_exclusive}" ]]; then
@@ -322,7 +322,7 @@ if [[ -n "${_arg_set_rulefile}" && -n "${_arg_set_rulefile_exclusive}" ]]; then
   exit 1
 fi
 
-
+touch ${BASEDIR}/containers-data/suricata/logs/eve.json && chmod 777 ${BASEDIR}/containers-data/suricata/logs/eve.json
 
 docker run --name suricata-replay --rm -it \
 --cap-add=net_admin --cap-add=sys_nice \


### PR DESCRIPTION
This PR should allow easy-setup.sh to run on mac, adding dummy interfaces, and touches eve.json to bypass some permission issue (this last part, https://github.com/nerok/SELKS/blob/ac83e471d6fde0975f989bed3afd0db4d652c93e/docker/scripts/readpcap.sh#L325, may have a better solution that I haven't found.