### PR TITLE
evebox: disable built-in TLS

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -159,6 +159,8 @@ services:
     image: jasonish/evebox:master
     command: ["-e", "http://elasticsearch:9200"]
     restart: ${RESTART_MODE:-unless-stopped}
+    environment:
+      - EVEBOX_HTTP_TLS_DISABLED=true
     networks:
       network:
         


### PR DESCRIPTION
TLS on by default in EveBox will soon land in the main branch of EveBox. Export the environment variable EVEBOX_HTTP_TLS_DISABLED=true to opt-out of this, as its no necessary in environments like SELKS where EveBox is already protected behind a reverse proxy.