### PR TITLE
evebox: disable built-in TLS and authentication

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -159,6 +159,9 @@ services:
     image: jasonish/evebox:master
     command: ["-e", "http://elasticsearch:9200"]
     restart: ${RESTART_MODE:-unless-stopped}
+    environment:
+      - EVEBOX_HTTP_TLS_ENABLED=false
+      - EVEBOX_AUTHENTICATION_REQUIRED=false
     networks:
       network:
         


### PR DESCRIPTION
TLS and authentication by default will soon be enabled in EveBox git master. For SELKS, set environment variables to opt-out of these features.

Closes: #445