### PR TITLE
Fix permissions of /etc/logrotate.d/suricata

### DIFF
--- a/docker/containers-data/suricata/etc/new_entrypoint.sh
+++ b/docker/containers-data/suricata/etc/new_entrypoint.sh
@@ -14,6 +14,8 @@ fix_perms() {
     chown -R suricata:suricata /var/lib/suricata
     chown -R suricata:suricata /var/log/suricata
     chown -R suricata:suricata /var/run/suricata
+
+    chown -R root:root /etc/logrotate.d/suricata
 }
 
 for src in /etc/suricata.dist/*; do


### PR DESCRIPTION
Set owner:group of docker/containers-data/suricata/logrotate/suricata inside the Docker container to root:root. Otherwise, these depend on who checked out the SELKS Git repository. logrotate may ignore the file, if it is not owned by root:root.