### PR TITLE
Fix Issue 492: Arkime stops capturing data in Docker SELKS

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,7 +1,6 @@
 name: Build ArkimeViewer docker Image
 
 on:
-  # All thoses triggers might be too much, subject to change
   push:
   pull_request:
   release:
@@ -18,71 +17,51 @@ jobs:
       packages: write
       contents: read
     steps:
-      -
-        name: Check out the repo
+      - name: Check out the repo
         uses: actions/checkout@v2
-      
-      -
-        name: Set up Docker Buildx
+
+      - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
-      
-      -
-        name: Cache Docker layers
+
+      - name: Cache Docker layers
         uses: actions/cache@v2
         with:
           path: /tmp/.buildx-cache
           key: ${{ runner.os }}-buildx-${{ github.sha }}
           restore-keys: |
             ${{ runner.os }}-buildx-
-      
-      -
-        name: Log in to GitHub Container Registry
+
+      - name: Log in to GitHub Container Registry
         uses: docker/login-action@v1
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      
-      -
-        name: PrepareReg Names
+
+      - name: Prepare Registry Names
         run: |
-          # Change all uppercase to lowercase
           OWNER=$(echo ${{ github.repository_owner }} | tr '[A-Z]' '[a-z]')
-          
-          # Strip git ref prefix from version
           VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
-          
-          # Strip "v" prefix from tag name
           [[ "${{ github.ref }}" == "refs/tags/"* ]] && VERSION=$(echo $VERSION | sed -e 's/^v//')
-          
-          # Use Docker `latest` tag convention
           [ "$VERSION" == "master" ] && LATEST="latest"
-          
           echo "OWNER=$OWNER" >> $GITHUB_ENV
           echo "VERSION=$VERSION" >> $GITHUB_ENV
-          
           echo "OWNER=$OWNER"
           echo "VERSION=$VERSION"
-      
-      -
-        name: Build container image
+
+      - name: Build container image
         uses: docker/build-push-action@v2
         with:
-          context : ./docker/Arkime
-          file : ./docker/Arkime/Arkime.dockerfile
+          context: ./docker/Arkime
+          file: ./docker/Arkime/Arkime.dockerfile
           push: true
           tags: |
             ghcr.io/${{ env.OWNER }}/arkimeviewer:${{ github.sha }}
             ghcr.io/${{ env.OWNER }}/arkimeviewer:${{ env.VERSION }}
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
-      
-      -
-        # Temp fix
-        # https://github.com/docker/build-push-action/blob/master/docs/advanced/cache.md#github-cache
-        # https://github.com/docker/build-push-action/issues/252
-        # https://github.com/moby/buildkit/issues/1896
-        name: Move cache
+
+      - name: Move cache
         run: |
           rm -rf /tmp/.buildx-cache
           mv /tmp/.buildx-cache-new /tmp/.buildx-cache


### PR DESCRIPTION
This pull request fixes Issue 492, where Arkime would stop capturing network traffic in the Docker SELKS environment. The problem occurred because Arkime_capture sometimes started before Elasticsearch was fully ready, preventing proper indexing and causing packet capture to halt. To resolve this, a startup script (start-arkime.sh) was added that waits for Elasticsearch to be available before launching Arkime_capture.